### PR TITLE
Fix RGB565 colors in 8bpp text and conversion

### DIFF
--- a/ugui.c
+++ b/ugui.c
@@ -1384,18 +1384,25 @@ void _UG_SendObjectPostrenderEvent( UG_WINDOW *wnd, UG_OBJECT *obj )
 }
 #endif
 
+/*
+ * Using only bitshifts would save some instruction cycles
+ * but this way the full color space remains (pure 0xFFFFFF)
+ */
 UG_U32 _UG_ConvertRGB565ToRGB888(UG_U16 c)
 {
    UG_U32 r,g,b;
 
    r = (c&0xF800)<<8;
    r += (r+7)>>5;
+   r &= 0xFF0000;
 
    g = (c&0x7E0)<<5;
    g += (g+3)>>6;
+   g &= 0x00FF00;
 
    b = (c&0x1F)<<3;
    b += (b+7)>>5;
+   b &= 0x0000FF;
 
    return (r | g | b);
 }

--- a/ugui.c
+++ b/ugui.c
@@ -986,9 +986,15 @@ UG_S16 _UG_PutChar( UG_CHAR chr, UG_S16 x, UG_S16 y, UG_COLOR fc, UG_COLOR bc)
        for( i=0;i<actual_char_width;i++ )
        {
          b = *data++;
+#ifdef UGUI_USE_COLOR_RGB888
          color = ((((fc & 0xFF) * b + (bc & 0xFF) * (256 - b)) >> 8) & 0xFF) |            //Blue component
                  ((((fc & 0xFF00) * b + (bc & 0xFF00) * (256 - b)) >> 8)  & 0xFF00) |     //Green component
                  ((((fc & 0xFF0000) * b + (bc & 0xFF0000) * (256 - b)) >> 8) & 0xFF0000); //Red component
+#else
+         color = ((((fc & 0x001F) * b + (bc & 0x1F) * (256 - b)) >> 8) & 0x001F) |        //Blue component
+                 ((((fc & 0x07E0) * b + (bc & 0x07E0) * (256 - b)) >> 8)  & 0x07E0) |     //Green component
+                 ((((fc & 0xF800) * b + (bc & 0xF800) * (256 - b)) >> 8) & 0xF800);       //Red component
+#endif
          if(driver)
          {
            push_pixels(1,color);                                                          // Accelerated output


### PR DESCRIPTION
In the RGB565 to RGB888 conversion some color bled through due to bitshifts without mask.
In the 8bpp mode the RGB565 mode was simply not implemented and always outputs RGB888 resulting in interesting color schemes.

#2 might be fixed by this and the commit for the ttf2ugui commit.